### PR TITLE
Re-/Store tracking state onResume

### DIFF
--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
@@ -21,6 +21,7 @@ public interface RunDo extends TextWatcher, WriteToArrayDeque {
     String REDO_TAG = "redo_queue";
     String OLD_TEXT_TAG = "old_text";
     String CONFIG_CHANGE_TAG = "return_from_config_change";
+    String TRACKING_TAG = "tracking_state";
 
     int DEFAULT_QUEUE_SIZE = 10;
     int DEFAULT_TIMER_LENGTH = 2000;

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
@@ -82,7 +82,7 @@ public class RunDoNative extends Fragment implements RunDo {
 
             if(isRunning) startCountdownRunnable();
 
-            trackingState = TRACKING_STARTED;
+            trackingState = savedInstanceState.getInt(TRACKING_TAG);
         }
 
     }
@@ -106,6 +106,7 @@ public class RunDoNative extends Fragment implements RunDo {
 
         if (isRunning) stopCountdownRunnable();
 
+        outState.putInt(TRACKING_TAG, trackingState);
     }
 
     @Override

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
@@ -79,7 +79,7 @@ public class RunDoSupport extends Fragment implements RunDo {
 
             if(isRunning) startCountdownRunnable();
 
-            trackingState = TRACKING_STARTED;
+            trackingState = savedInstanceState.getInt(TRACKING_TAG);
         }
 
     }
@@ -103,6 +103,7 @@ public class RunDoSupport extends Fragment implements RunDo {
 
         if (isRunning) stopCountdownRunnable();
 
+        outState.putInt(TRACKING_TAG, trackingState);
     }
 
     @Override


### PR DESCRIPTION
When merging this PR, RunDo will save and restore its TRACKING_STATE onResume. This will fix #6 "After rotation (on resume), undo and redo are not working".

Please be aware that I only tested the changes within my app and probably didn't cover all cases, leaving a chance to introduce new bugs or unintended side-effects.