### PR TITLE
Get queue size

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,20 @@ Implement [`RunDo.Callbacks`](http://ppartisan.github.io/RunDo/JavaDoc/com/werdp
     public void redoCalled() {
     }
     
+Additionally, following callbacks will be fired to signalize when a queue becomes empty or filled:
+
+    @Override
+    public void undoEmpty() {
+    }
+
+    @Override
+    public void redoEmpty() {
+    }
+
+    @Override
+    public void undoAvailable() {
+    }
+
+    @Override
+    public void redoAvailable() {
+    }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ For example:
 
     }
     
+
+#### Retrieve the queues state
+
+Use [`canUndo()`](http://ppartisan.github.io/RunDo/JavaDoc/com/werdpressed/partisan/rundo/RunDo.html#canUndo()) or [`canRedo()`](http://ppartisan.github.io/RunDo/JavaDoc/com/werdpressed/partisan/rundo/RunDo.html#canRedo()) to know if any change is available to undo or redo.
+
 #### Tweaking Parameters
 
 There are two ways to customise `RunDo` objects; [`setQueueSize(int size)`](http://ppartisan.github.io/RunDo/JavaDoc/com/werdpressed/partisan/rundo/RunDo.html#setQueueSize(int)) and [`setTimerLength(long lengthInMillis)`](http://ppartisan.github.io/RunDo/JavaDoc/com/werdpressed/partisan/rundo/RunDo.html#setTimerLength(long)).

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
@@ -89,6 +89,28 @@ public interface RunDo extends TextWatcher, WriteToArrayDeque {
          */
         void redoCalled();
 
+        /**
+         * Fired when there are no further changes to undo
+         */
+        void undoEmpty();
+
+        /**
+         * Fired when there are no further changes to redo
+         */
+        void redoEmpty();
+
+        /**
+         * Fired when any change becomes available to undo.
+         * Only fired when previously no undo was available (see {@link #undoEmpty()})
+         */
+        void undoAvailable();
+
+        /**
+         * Fired when any change becomes available to redo.
+         * Only fired when previously no redo was available (see {@link #redoEmpty()})
+         */
+        void redoAvailable();
+
     }
 
     /**

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDo.java
@@ -45,6 +45,18 @@ public interface RunDo extends TextWatcher, WriteToArrayDeque {
     void setTimerLength(long lengthInMillis);
 
     /**
+     * @return True if any change is available to undo.
+     * @see #undo()
+     */
+    boolean canUndo();
+
+    /**
+     * @return True if any change is available to redo.
+     * @see #redo()
+     */
+    boolean canRedo();
+
+    /**
      * Updates attached {@link EditText} with text from the last entry in the undo queue, such that
      * it reverts to an earlier state.
      */

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
@@ -391,7 +391,7 @@ public class RunDoNative extends Fragment implements RunDo {
     }
 
     private static boolean isQueueEmpty(FixedSizeArrayDeque<SubtractStrings.Item> queue) {
-        return queue.peek() == null;
+        return queue == null || queue.peek() == null;
     }
 
     private void restartCountdownRunnableImmediately() {

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
@@ -218,7 +218,7 @@ public class RunDoNative extends Fragment implements RunDo {
      */
     @Override
     public boolean canUndo() {
-        return isQueueEmpty(mUndoQueue);
+        return !isQueueEmpty(mUndoQueue);
     }
 
     /**
@@ -227,7 +227,7 @@ public class RunDoNative extends Fragment implements RunDo {
      */
     @Override
     public boolean canRedo() {
-        return isQueueEmpty(mRedoQueue);
+        return !isQueueEmpty(mRedoQueue);
     }
 
     /**

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
@@ -122,7 +122,7 @@ public class RunDoNative extends Fragment implements RunDo {
         if (trackingState == TRACKING_ENDED) {
 
             //Redo Queue should only be required as response to Undo calls. Otherwise clear.
-            mRedoQueue.clear();
+            clearRedoQueue();
 
             startCountdownRunnable();
             trackingState = TRACKING_CURRENT;
@@ -175,7 +175,7 @@ public class RunDoNative extends Fragment implements RunDo {
     @Override
     public void notifyArrayDequeDataReady(SubtractStrings.Item item) {
 
-        mUndoQueue.addFirst(item);
+        fillUndoQueue(item);
 
         mOldText = mTextLink.getEditTextForRunDo().getText().toString();
 
@@ -226,14 +226,14 @@ public class RunDoNative extends Fragment implements RunDo {
 
         trackingState = TRACKING_STARTED;
 
-        if (mUndoQueue.peek() == null) {
+        if (isQueueEmpty(mUndoQueue)) {
             //Log.e(TAG, "Undo Queue Empty");
             return;
         }
 
         try {
 
-            SubtractStrings.Item temp = mUndoQueue.poll();
+            SubtractStrings.Item temp = pollUndoQueue();
 
             switch (temp.getDeviationType()) {
                 case SubtractStrings.ADDITION:
@@ -261,7 +261,7 @@ public class RunDoNative extends Fragment implements RunDo {
 
             mTextLink.getEditTextForRunDo().setSelection(temp.getFirstDeviation());
 
-            mRedoQueue.addFirst(temp);
+            fillRedoQueue(temp);
 
             if (mCallbacks != null) mCallbacks.undoCalled();
 
@@ -282,14 +282,14 @@ public class RunDoNative extends Fragment implements RunDo {
 
         trackingState = TRACKING_STARTED;
 
-        if (mRedoQueue.peek() == null) {
+        if (isQueueEmpty(mRedoQueue)) {
             //Log.e(TAG, "Redo Queue Empty");
             return;
         }
 
         try {
 
-            SubtractStrings.Item temp = mRedoQueue.poll();
+            SubtractStrings.Item temp = pollRedoQueue();
 
             switch (temp.getDeviationType()) {
                 case SubtractStrings.ADDITION:
@@ -318,7 +318,7 @@ public class RunDoNative extends Fragment implements RunDo {
 
             mTextLink.getEditTextForRunDo().setSelection(temp.getFirstDeviation());
 
-            mUndoQueue.addFirst(temp);
+            fillUndoQueue(temp);
 
             if (mCallbacks != null) mCallbacks.redoCalled();
 
@@ -336,8 +336,44 @@ public class RunDoNative extends Fragment implements RunDo {
      */
     @Override
     public void clearAllQueues() {
+        clearUndoQueue();
+        clearRedoQueue();
+    }
+
+    private void clearUndoQueue() {
         mUndoQueue.clear();
+        if (mCallbacks != null) mCallbacks.undoEmpty();
+    }
+
+    private void clearRedoQueue() {
         mRedoQueue.clear();
+        if (mCallbacks != null) mCallbacks.redoEmpty();
+    }
+
+    private SubtractStrings.Item pollUndoQueue() {
+      SubtractStrings.Item item = mUndoQueue.poll();
+      if (mCallbacks != null && isQueueEmpty(mUndoQueue)) mCallbacks.undoEmpty();
+      return item;
+    }
+
+    private SubtractStrings.Item pollRedoQueue() {
+      SubtractStrings.Item item = mRedoQueue.poll();
+      if (mCallbacks != null && isQueueEmpty(mRedoQueue)) mCallbacks.redoEmpty();
+      return item;
+    }
+
+    private void fillUndoQueue(SubtractStrings.Item item) {
+        if (mCallbacks != null && isQueueEmpty(mUndoQueue)) mCallbacks.undoAvailable();
+        mUndoQueue.addFirst(item);
+    }
+
+    private void fillRedoQueue(SubtractStrings.Item item) {
+        if (mCallbacks != null && isQueueEmpty(mRedoQueue)) mCallbacks.redoAvailable();
+        mRedoQueue.addFirst(item);
+    }
+
+    private static boolean isQueueEmpty(FixedSizeArrayDeque<SubtractStrings.Item> queue) {
+        return queue.peek() == null;
     }
 
     private void restartCountdownRunnableImmediately() {

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoNative.java
@@ -214,6 +214,24 @@ public class RunDoNative extends Fragment implements RunDo {
 
     /**
      *
+     * @see {@link RunDo#canUndo()}
+     */
+    @Override
+    public boolean canUndo() {
+        return isQueueEmpty(mUndoQueue);
+    }
+
+    /**
+     *
+     * @see {@link RunDo#canRedo()}
+     */
+    @Override
+    public boolean canRedo() {
+        return isQueueEmpty(mRedoQueue);
+    }
+
+    /**
+     *
      * @see {@link RunDo#undo()}
      */
     @Override

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
@@ -215,7 +215,7 @@ public class RunDoSupport extends Fragment implements RunDo {
      */
     @Override
     public boolean canUndo() {
-        return isQueueEmpty(mUndoQueue);
+        return !isQueueEmpty(mUndoQueue);
     }
 
     /**
@@ -224,7 +224,7 @@ public class RunDoSupport extends Fragment implements RunDo {
      */
     @Override
     public boolean canRedo() {
-        return isQueueEmpty(mRedoQueue);
+        return !isQueueEmpty(mRedoQueue);
     }
 
     /**

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
@@ -388,7 +388,7 @@ public class RunDoSupport extends Fragment implements RunDo {
     }
 
     private static boolean isQueueEmpty(FixedSizeArrayDeque<SubtractStrings.Item> queue) {
-        return queue.peek() == null;
+        return queue == null || queue.peek() == null;
     }
 
     private void restartCountdownRunnableImmediately() {

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
@@ -211,6 +211,24 @@ public class RunDoSupport extends Fragment implements RunDo {
 
     /**
      *
+     * @see {@link RunDo#canUndo()}
+     */
+    @Override
+    public boolean canUndo() {
+        return isQueueEmpty(mUndoQueue);
+    }
+
+    /**
+     *
+     * @see {@link RunDo#canRedo()}
+     */
+    @Override
+    public boolean canRedo() {
+        return isQueueEmpty(mRedoQueue);
+    }
+
+    /**
+     *
      * @see {@link RunDo#undo()}
      */
     @Override

--- a/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
+++ b/rundo/src/main/java/com/werdpressed/partisan/rundo/RunDoSupport.java
@@ -172,7 +172,7 @@ public class RunDoSupport extends Fragment implements RunDo {
     @Override
     public void notifyArrayDequeDataReady(SubtractStrings.Item item) {
 
-        mUndoQueue.addFirst(item);
+        fillUndoQueue(item);
 
         mOldText = mTextLink.getEditTextForRunDo().getText().toString();
 
@@ -223,14 +223,14 @@ public class RunDoSupport extends Fragment implements RunDo {
 
         trackingState = TRACKING_STARTED;
 
-        if (mUndoQueue.peek() == null) {
+        if (isQueueEmpty(mUndoQueue)) {
             //Log.e(TAG, "Undo Queue Empty");
             return;
         }
 
         try {
 
-            SubtractStrings.Item temp = mUndoQueue.poll();
+            SubtractStrings.Item temp = pollUndoQueue();
 
             switch (temp.getDeviationType()) {
                 case SubtractStrings.ADDITION:
@@ -258,7 +258,7 @@ public class RunDoSupport extends Fragment implements RunDo {
 
             mTextLink.getEditTextForRunDo().setSelection(temp.getFirstDeviation());
 
-            mRedoQueue.addFirst(temp);
+            fillRedoQueue(temp);
 
             if (mCallbacks != null) mCallbacks.undoCalled();
 
@@ -279,14 +279,14 @@ public class RunDoSupport extends Fragment implements RunDo {
 
         trackingState = TRACKING_STARTED;
 
-        if (mRedoQueue.peek() == null) {
+        if (isQueueEmpty(mRedoQueue)) {
             //Log.e(TAG, "Redo Queue Empty");
             return;
         }
 
         try {
 
-            SubtractStrings.Item temp = mRedoQueue.poll();
+            SubtractStrings.Item temp = pollRedoQueue();
 
             switch (temp.getDeviationType()) {
                 case SubtractStrings.ADDITION:
@@ -333,8 +333,44 @@ public class RunDoSupport extends Fragment implements RunDo {
      */
     @Override
     public void clearAllQueues() {
+        clearUndoQueue();
+        clearRedoQueue();
+    }
+
+    private void clearUndoQueue() {
         mUndoQueue.clear();
+        if (mCallbacks != null) mCallbacks.undoEmpty();
+    }
+
+    private void clearRedoQueue() {
         mRedoQueue.clear();
+        if (mCallbacks != null) mCallbacks.redoEmpty();
+    }
+
+    private SubtractStrings.Item pollUndoQueue() {
+        SubtractStrings.Item item = mUndoQueue.poll();
+        if (mCallbacks != null && isQueueEmpty(mUndoQueue)) mCallbacks.undoEmpty();
+        return item;
+    }
+
+    private SubtractStrings.Item pollRedoQueue() {
+        SubtractStrings.Item item = mRedoQueue.poll();
+        if (mCallbacks != null && isQueueEmpty(mRedoQueue)) mCallbacks.redoEmpty();
+        return item;
+    }
+
+    private void fillUndoQueue(SubtractStrings.Item item) {
+        if (mCallbacks != null && isQueueEmpty(mUndoQueue)) mCallbacks.undoAvailable();
+        mUndoQueue.addFirst(item);
+    }
+
+    private void fillRedoQueue(SubtractStrings.Item item) {
+        if (mCallbacks != null && isQueueEmpty(mRedoQueue)) mCallbacks.redoAvailable();
+        mRedoQueue.addFirst(item);
+    }
+
+    private static boolean isQueueEmpty(FixedSizeArrayDeque<SubtractStrings.Item> queue) {
+        return queue.peek() == null;
     }
 
     private void restartCountdownRunnableImmediately() {


### PR DESCRIPTION
When mergin this PR, then RunDo will be advanced by two functions to retrieve the undo and redo queues state (empty or not) (RunDo#canUndo() and RunDo#canRedo()).

Additionally, several callbacks will be added, to signalize when the undo or redo queue becomes empty (undoEmpty() , redoEmpty()) or available (undoAvailable() , redoAvailable()).

This will solve #2 Get queue size.